### PR TITLE
Various Improvements to the tools

### DIFF
--- a/ipmifw/ASpeed.py
+++ b/ipmifw/ASpeed.py
@@ -21,7 +21,7 @@ class ASpeed:
 			if extract:
 				imageend = imagestart + length
 				print "Dumping 0x%x to 0x%X to data/%s" % (imagestart, imageend, filename)
-				with open('data/%s' % filename,'w') as f:
+				with open('data/%s' % filename,'wb') as f:
 					f.write(ipmifw[imagestart:imageend])
 
 				computed_image_checksum = zlib.crc32(ipmifw[imagestart:imageend]) & 0xffffffff

--- a/ipmifw/ASpeed.py
+++ b/ipmifw/ASpeed.py
@@ -1,135 +1,134 @@
-#!/usr/local/bin/python2.7
-
+#!/usr/bin/python
 import re, hashlib, zlib, struct
 from ipmifw.FirmwareImage import FirmwareImage
 from ipmifw.FirmwareFooter import FirmwareFooter
 
 
 class ASpeed:
-	def parse(self, ipmifw, extract, config):
-		footer = ipmifw[0x01fc0000:]
-		imagenum = 1
-		# There's a nice handy block at the end of the file that gives information about all the embedded images!
-		for (imagestart, length, checksum, filename) in re.findall("\[img\]: ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z\-_.]+)", footer):
-			imagestart = int(imagestart,16)
-			length = int(length,16)
-			checksum = int(checksum,16)
+    def parse(self, ipmifw, extract, config):
+        footer = ipmifw[0x01fc0000:].decode('ISO-8859-1')
+        imagenum = 1
+        # There's a nice handy block at the end of the file that gives information about all the embedded images!
+        for (imagestart, length, checksum, filename) in re.findall("\[img\]: ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z\-_.]+)", footer):
+            imagestart = int(imagestart,16)
+            length = int(length,16)
+            checksum = int(checksum,16)
 
-			print "Firmware image: %i Name: %s Base: 0x%x Length: 0x%x CRC32: 0x%x" % (imagenum, filename, imagestart, length, checksum)
+            print("Firmware image: %i Name: %s Base: 0x%x Length: 0x%x CRC32: 0x%x" % (imagenum, filename, imagestart, length, checksum))
 
 
-			if extract:
-				imageend = imagestart + length
-				print "Dumping 0x%x to 0x%X to data/%s" % (imagestart, imageend, filename)
-				with open('data/%s' % filename,'wb') as f:
-					f.write(ipmifw[imagestart:imageend])
+            if extract:
+                imageend = imagestart + length
+                print("Dumping 0x%x to 0x%X to data/%s" % (imagestart, imageend, filename))
+                with open('data/%s' % filename,'wb') as f:
+                    f.write(ipmifw[imagestart:imageend])
 
-				computed_image_checksum = zlib.crc32(ipmifw[imagestart:imageend]) & 0xffffffff
-				if computed_image_checksum != checksum:
-					print "Warniing: Image checksum mismatch, footer: 0x%x computed 0x%x" % (checksum, computed_image_checksum)
-				else:
-					print "Image checksum matches"
+                computed_image_checksum = zlib.crc32(ipmifw[imagestart:imageend]) & 0xffffffff
+                if computed_image_checksum != checksum:
+                    print("Warning: Image checksum mismatch, footer: 0x%x computed 0x%x" % (checksum, computed_image_checksum))
+                else:
+                    print("Image checksum matches")
 
-			config.set('images', str(imagenum), 'present')
-			configkey = 'image_%i' % imagenum
-			config.add_section(configkey)
-			config.set(configkey, 'name', filename)
-			config.set(configkey, 'base_addr', hex(imagestart))
-			config.set(configkey, 'length', hex(length))
-			config.set(configkey, 'checksum', hex(checksum))
+            config.set('images', str(imagenum), 'present')
+            configkey = 'image_%i' % imagenum
+            config.add_section(configkey)
+            config.set(configkey, 'name', str(filename))
+            config.set(configkey, 'base_addr', hex(imagestart))
+            config.set(configkey, 'length', hex(length))
+            config.set(configkey, 'checksum', hex(checksum))
 
-			imagenum += 1
+            imagenum += 1
 
-		# Next, find and validate the global footer
-		for imageFooter in re.findall("ATENs_FW(.{20})",ipmifw,re.DOTALL):
+        # Next, find and validate the global footer
+        for imageFooter in re.findall(b"ATENs_FW(.{20})", ipmifw, re.DOTALL):
+            (rev1, rev2, rootfs_crc, rootfs_len, fwtag1, webfs_crc, webfs_len, fwtag2) = struct.unpack(b"<BB4s4sB4s4sB", imageFooter)
+            if fwtag1 != 0x71 or fwtag2 != 0x17:
+                print("Error matching footer tags")
+            else:
+                len2 = config.get('image_2', 'length')
+                crc2 = config.get('image_2', 'checksum')
+                len4 = config.get('image_4', 'length')
+                crc4 = config.get('image_4', 'checksum')
 
-			(rev1, rev2, rootfs_crc, rootfs_len, fwtag1, webfs_crc, webfs_len, fwtag2) = struct.unpack("<bb4s4sb4s4sb", imageFooter)
-			if fwtag1 != 0x71 or fwtag2 != 0x17:
-				print "Error matching footer tags"
-			else:
-				len2 = config.get('image_2', 'length')
-				crc2 = config.get('image_2', 'checksum')
-				len4 = config.get('image_4', 'length')
-				crc4 = config.get('image_4', 'checksum')
-				if rootfs_len != len2[2:6] or rootfs_crc != crc2[2:6]:
-					print "Root_fs image info does not match"
-				elif webfs_len != len4[2:6] or webfs_crc != crc4[2:6]:
-					print "Web_fs image info does not match"
-				else:
-					print "Footer OK, rev: %x.%x" % (rev1, rev2)
+                if rootfs_len.decode('ISO-8859-1') != len2[2:6] or rootfs_crc.decode('ISO-8859-1') != crc2[2:6]:
+                    print("Root_fs image info does not match")
+                elif webfs_len.decode('ISO-8859-1') != len4[2:6] or webfs_crc.decode('ISO-8859-1') != crc4[2:6]:
+                    print("Web_fs image info does not match")
+                else:
+                    print("Footer OK, rev: %x.%x" % (rev1, rev2))
 
-			config.set('global', 'major_version', rev1)
-			config.set('global', 'minor_version', rev2)
+            config.set('global', 'major_version', str(rev1))
+            config.set('global', 'minor_version', str(rev2))
 
-	def init_image(self, new_image, total_size):
-		# Aspeed image has some parts filled with nulls
-		if total_size < 0x1F40000:
-			print "Unexpected ASpeed image size"
-			os.exit(1)
-		# space for uboot bootloader
-		for i in range(0,0x100000):
-			new_image.write('\xFF')
-		# nvram block, not referenced in the footer
-		for i in range(0x100000,0x400000):
-			new_image.write('\x00')
-		# root_fs, kernel and web_fs
-		for i in range(0x400000,0x1F40000):
-			new_image.write('\xFF')
-		# bootloader env aka footer
-		for i in range(0x1F40000,total_size):
-			new_image.write('\x00')
+    def init_image(self, new_image, total_size):
+        # Aspeed image has some parts filled with nulls
+        if total_size < 0x1F40000:
+            print("Unexpected ASpeed image size")
+            os.exit(1)
+        # space for uboot bootloader
+        for i in range(0,0x100000):
+            new_image.write(b'\xFF')
+        # nvram block, not referenced in the footer
+        for i in range(0x100000,0x400000):
+            new_image.write(b'\x00')
+        # root_fs, kernel and web_fs
+        for i in range(0x400000,0x1F40000):
+            new_image.write(b'\xFF')
+        # bootloader env aka footer
+        for i in range(0x1F40000,total_size):
+            new_image.write(b'\x00')
 
-        def write_bootloader(self, new_image):
-		pass
+    def write_bootloader(self, new_image):
+        pass
 
-	def process_image(self, config, imagenum, images, cur_image):
-		# ASpeed seems to place global footer right after the last image
-		# The size contains also part of the footer, so we extract it
-		# But if the image is re-packed, that part is lost
-		# so we need to check and add it, if needed
-		if imagenum == images[-1]:
-			if cur_image[-10:-2] != 'ATENs_FW':
-				footer = FirmwareFooter()
-				footer.rev1 = int(config.get('global','major_version'),0)
-				footer.rev2 = int(config.get('global','minor_version'),0)
-				footer.footerver = int(config.get('global','footer_version'),0)
-				footer.rootfs_nfo = "00000000"
-				footer.webfs_nfo = "00000000"
-				return cur_image + footer.getRawString()[:10]
-		return cur_image
+    def process_image(self, config, imagenum, images, cur_image):
+        # ASpeed seems to place global footer right after the last image
+        # The size contains also part of the footer, so we extract it
+        # But if the image is re-packed, that part is lost
+        # so we need to check and add it, if needed
+        if imagenum == images[-1]:
+            if cur_image[-10:-2] != b"ATENs_FW":
+                footer = FirmwareFooter()
+                footer.rev1 = int(config.get('global','major_version'),0)
+                footer.rev2 = int(config.get('global','minor_version'),0)
+                footer.footerver = int(config.get('global','footer_version'),0)
+                footer.rootfs_nfo = "00000000"
+                footer.webfs_nfo = "00000000"
+                return cur_image + footer.getRawString()[:10]
+        return cur_image
 
-	def write_image_footer(self, new_image, cur_image, config, configkey, imagenum, base_addr, name):
-		# no image footer for ASpeed, but check for changes
-		curcrc = int(config.get(configkey, 'curcrc'), 0)
-		if curcrc == int(config.get(configkey, 'checksum'), 0):
-			print "  Image unchanged"
-		else:
-			print "  Image modified"
+    def write_image_footer(self, new_image, cur_image, config, configkey, imagenum, base_addr, name):
+        # no image footer for ASpeed, but check for changes
+        curcrc = int(config.get(configkey, 'curcrc'), 0)
+        if curcrc == int(config.get(configkey, 'checksum'), 0):
+            print("  Image unchanged")
+        else:
+            print("  Image modified")
 
-		return (new_image.tell(), None)
+        return (new_image.tell(), None)
 
-	def prepare_global_footer(self, config, footer, footerpos, curblockend):
-		# ASpeed specific parameters
-		crc2 = config.get('image_2', 'curcrc')
-		len2 = config.get('image_2', 'curlen')
-		crc4 = config.get('image_4', 'curcrc')
-		len4 = config.get('image_4', 'curlen')
-		footer.rootfs_nfo = '%4s%4s' % (crc2[2:6], len2[2:6])
-		footer.webfs_nfo = '%4s%4s' % (crc4[2:6], len4[2:6])
-		# ASpeed seems to place global footer right after the last image
-		return footerpos - 10
+    def prepare_global_footer(self, config, footer, footerpos, curblockend):
+        # ASpeed specific parameters
+        crc2 = config.get('image_2', 'curcrc')
+        len2 = config.get('image_2', 'curlen')
+        crc4 = config.get('image_4', 'curcrc')
+        len4 = config.get('image_4', 'curlen')
+        footer.rootfs_nfo = '%4s%4s' % (crc2[2:6], len2[2:6])
+        footer.webfs_nfo = '%4s%4s' % (crc4[2:6], len4[2:6])
+        # ASpeed seems to place global footer right after the last image
+        return footerpos - 10
 
-	def write_global_index(self, config, new_image, images):
-		# add ASpeed specific index
-		new_image.seek(0x1FC0000)
-		for imagenum in images:
-			configkey = 'image_%i' % imagenum
-			img_base = int(config.get(configkey, 'base_addr'),0)
-			img_len = int(config.get(configkey, 'curlen'),0)
-			img_crc = int(config.get(configkey, 'curcrc'),0)
-			img_name = config.get(configkey, 'name')
+    def write_global_index(self, config, new_image, images):
+        # add ASpeed specific index
+        new_image.seek(0x1FC0000)
+        for imagenum in images:
+            configkey = 'image_%i' % imagenum
+            img_base = int(config.get(configkey, 'base_addr'),0)
+            img_len = int(config.get(configkey, 'curlen'),0)
+            img_crc = int(config.get(configkey, 'curcrc'),0)
+            img_name = config.get(configkey, 'name')
 
-			new_image.write("[img]: ")
-			new_image.write("%x %x %x %s" % (img_base, img_len, img_crc, img_name))
-		new_image.write("[end]")
- 
+            new_image.write(b'[img]: ')
+            new_image.write(("%x %x %x %s" % (img_base, img_len, img_crc, img_name)).encode('ISO-8859-1'))
+        new_image.write(b'[end]')
+

--- a/ipmifw/ASpeed.py
+++ b/ipmifw/ASpeed.py
@@ -6,59 +6,85 @@ from ipmifw.FirmwareFooter import FirmwareFooter
 
 class ASpeed:
     def parse(self, ipmifw, extract, config):
-        footer = ipmifw[0x01fc0000:].decode('ISO-8859-1')
+        footer = ipmifw[0x01FC0000:].decode("ISO-8859-1")
         imagenum = 1
         # There's a nice handy block at the end of the file that gives information about all the embedded images!
-        for (imagestart, length, checksum, filename) in re.findall("\[img\]: ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z\-_.]+)", footer):
-            imagestart = int(imagestart,16)
-            length = int(length,16)
-            checksum = int(checksum,16)
+        for (imagestart, length, checksum, filename) in re.findall(
+            "\[img\]: ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z\-_.]+)", footer
+        ):
+            imagestart = int(imagestart, 16)
+            length = int(length, 16)
+            checksum = int(checksum, 16)
 
-            print("Firmware image: %i Name: %s Base: 0x%x Length: 0x%x CRC32: 0x%x" % (imagenum, filename, imagestart, length, checksum))
-
+            print(
+                "Firmware image: %i Name: %s Base: 0x%x Length: 0x%x CRC32: 0x%x"
+                % (imagenum, filename, imagestart, length, checksum)
+            )
 
             if extract:
                 imageend = imagestart + length
-                print("Dumping 0x%x to 0x%X to data/%s" % (imagestart, imageend, filename))
-                with open('data/%s' % filename,'wb') as f:
+                print(
+                    "Dumping 0x%x to 0x%X to data/%s" % (imagestart, imageend, filename)
+                )
+                with open("data/%s" % filename, "wb") as f:
                     f.write(ipmifw[imagestart:imageend])
 
-                computed_image_checksum = zlib.crc32(ipmifw[imagestart:imageend]) & 0xffffffff
+                computed_image_checksum = (
+                    zlib.crc32(ipmifw[imagestart:imageend]) & 0xFFFFFFFF
+                )
                 if computed_image_checksum != checksum:
-                    print("Warning: Image checksum mismatch, footer: 0x%x computed 0x%x" % (checksum, computed_image_checksum))
+                    print(
+                        "Warning: Image checksum mismatch, footer: 0x%x computed 0x%x"
+                        % (checksum, computed_image_checksum)
+                    )
                 else:
                     print("Image checksum matches")
 
-            config.set('images', str(imagenum), 'present')
-            configkey = 'image_%i' % imagenum
+            config.set("images", str(imagenum), "present")
+            configkey = "image_%i" % imagenum
             config.add_section(configkey)
-            config.set(configkey, 'name', str(filename))
-            config.set(configkey, 'base_addr', hex(imagestart))
-            config.set(configkey, 'length', hex(length))
-            config.set(configkey, 'checksum', hex(checksum))
+            config.set(configkey, "name", str(filename))
+            config.set(configkey, "base_addr", hex(imagestart))
+            config.set(configkey, "length", hex(length))
+            config.set(configkey, "checksum", hex(checksum))
 
             imagenum += 1
 
         # Next, find and validate the global footer
         for imageFooter in re.findall(b"ATENs_FW(.{20})", ipmifw, re.DOTALL):
-            (rev1, rev2, rootfs_crc, rootfs_len, fwtag1, webfs_crc, webfs_len, fwtag2) = struct.unpack(b"<BB4s4sB4s4sB", imageFooter)
+            (
+                rev1,
+                rev2,
+                rootfs_crc,
+                rootfs_len,
+                fwtag1,
+                webfs_crc,
+                webfs_len,
+                fwtag2,
+            ) = struct.unpack(b"<BB4s4sB4s4sB", imageFooter)
             if fwtag1 != 0x71 or fwtag2 != 0x17:
                 print("Error matching footer tags")
             else:
-                len2 = config.get('image_2', 'length')
-                crc2 = config.get('image_2', 'checksum')
-                len4 = config.get('image_4', 'length')
-                crc4 = config.get('image_4', 'checksum')
+                len2 = config.get("image_2", "length")
+                crc2 = config.get("image_2", "checksum")
+                len4 = config.get("image_4", "length")
+                crc4 = config.get("image_4", "checksum")
 
-                if rootfs_len.decode('ISO-8859-1') != len2[2:6] or rootfs_crc.decode('ISO-8859-1') != crc2[2:6]:
+                if (
+                    rootfs_len.decode("ISO-8859-1") != len2[2:6]
+                    or rootfs_crc.decode("ISO-8859-1") != crc2[2:6]
+                ):
                     print("Root_fs image info does not match")
-                elif webfs_len.decode('ISO-8859-1') != len4[2:6] or webfs_crc.decode('ISO-8859-1') != crc4[2:6]:
+                elif (
+                    webfs_len.decode("ISO-8859-1") != len4[2:6]
+                    or webfs_crc.decode("ISO-8859-1") != crc4[2:6]
+                ):
                     print("Web_fs image info does not match")
                 else:
                     print("Footer OK, rev: %x.%x" % (rev1, rev2))
 
-            config.set('global', 'major_version', str(rev1))
-            config.set('global', 'minor_version', str(rev2))
+            config.set("global", "major_version", str(rev1))
+            config.set("global", "minor_version", str(rev2))
 
     def init_image(self, new_image, total_size):
         # Aspeed image has some parts filled with nulls
@@ -66,17 +92,17 @@ class ASpeed:
             print("Unexpected ASpeed image size")
             os.exit(1)
         # space for uboot bootloader
-        for i in range(0,0x100000):
-            new_image.write(b'\xFF')
+        for i in range(0, 0x100000):
+            new_image.write(b"\xFF")
         # nvram block, not referenced in the footer
-        for i in range(0x100000,0x400000):
-            new_image.write(b'\x00')
+        for i in range(0x100000, 0x400000):
+            new_image.write(b"\x00")
         # root_fs, kernel and web_fs
-        for i in range(0x400000,0x1F40000):
-            new_image.write(b'\xFF')
+        for i in range(0x400000, 0x1F40000):
+            new_image.write(b"\xFF")
         # bootloader env aka footer
-        for i in range(0x1F40000,total_size):
-            new_image.write(b'\x00')
+        for i in range(0x1F40000, total_size):
+            new_image.write(b"\x00")
 
     def write_bootloader(self, new_image):
         pass
@@ -89,18 +115,20 @@ class ASpeed:
         if imagenum == images[-1]:
             if cur_image[-10:-2] != b"ATENs_FW":
                 footer = FirmwareFooter()
-                footer.rev1 = int(config.get('global','major_version'),0)
-                footer.rev2 = int(config.get('global','minor_version'),0)
-                footer.footerver = int(config.get('global','footer_version'),0)
+                footer.rev1 = int(config.get("global", "major_version"), 0)
+                footer.rev2 = int(config.get("global", "minor_version"), 0)
+                footer.footerver = int(config.get("global", "footer_version"), 0)
                 footer.rootfs_nfo = "00000000"
                 footer.webfs_nfo = "00000000"
                 return cur_image + footer.getRawString()[:10]
         return cur_image
 
-    def write_image_footer(self, new_image, cur_image, config, configkey, imagenum, base_addr, name):
+    def write_image_footer(
+        self, new_image, cur_image, config, configkey, imagenum, base_addr, name
+    ):
         # no image footer for ASpeed, but check for changes
-        curcrc = int(config.get(configkey, 'curcrc'), 0)
-        if curcrc == int(config.get(configkey, 'checksum'), 0):
+        curcrc = int(config.get(configkey, "curcrc"), 0)
+        if curcrc == int(config.get(configkey, "checksum"), 0):
             print("  Image unchanged")
         else:
             print("  Image modified")
@@ -109,12 +137,12 @@ class ASpeed:
 
     def prepare_global_footer(self, config, footer, footerpos, curblockend):
         # ASpeed specific parameters
-        crc2 = config.get('image_2', 'curcrc')
-        len2 = config.get('image_2', 'curlen')
-        crc4 = config.get('image_4', 'curcrc')
-        len4 = config.get('image_4', 'curlen')
-        footer.rootfs_nfo = '%4s%4s' % (crc2[2:6], len2[2:6])
-        footer.webfs_nfo = '%4s%4s' % (crc4[2:6], len4[2:6])
+        crc2 = config.get("image_2", "curcrc")
+        len2 = config.get("image_2", "curlen")
+        crc4 = config.get("image_4", "curcrc")
+        len4 = config.get("image_4", "curlen")
+        footer.rootfs_nfo = "%4s%4s" % (crc2[2:6], len2[2:6])
+        footer.webfs_nfo = "%4s%4s" % (crc4[2:6], len4[2:6])
         # ASpeed seems to place global footer right after the last image
         return footerpos - 10
 
@@ -122,13 +150,16 @@ class ASpeed:
         # add ASpeed specific index
         new_image.seek(0x1FC0000)
         for imagenum in images:
-            configkey = 'image_%i' % imagenum
-            img_base = int(config.get(configkey, 'base_addr'),0)
-            img_len = int(config.get(configkey, 'curlen'),0)
-            img_crc = int(config.get(configkey, 'curcrc'),0)
-            img_name = config.get(configkey, 'name')
+            configkey = "image_%i" % imagenum
+            img_base = int(config.get(configkey, "base_addr"), 0)
+            img_len = int(config.get(configkey, "curlen"), 0)
+            img_crc = int(config.get(configkey, "curcrc"), 0)
+            img_name = config.get(configkey, "name")
 
-            new_image.write(b'[img]: ')
-            new_image.write(("%x %x %x %s" % (img_base, img_len, img_crc, img_name)).encode('ISO-8859-1'))
-        new_image.write(b'[end]')
-
+            new_image.write(b"[img]: ")
+            new_image.write(
+                ("%x %x %x %s" % (img_base, img_len, img_crc, img_name)).encode(
+                    "ISO-8859-1"
+                )
+            )
+        new_image.write(b"[end]")

--- a/ipmifw/FirmwareFooter.py
+++ b/ipmifw/FirmwareFooter.py
@@ -1,59 +1,61 @@
+#!/usr/bin/python
+
 import struct, zlib
 
 class FirmwareFooter:
-	# Footer version 1:
-	# ATENs_FW MAJOR MINOR CHECKSUM
+    # Footer version 1:
+    # ATENs_FW MAJOR MINOR CHECKSUM
 
-	# Footer version 2:
-	# ATENs_FW MAJORVER MINORVER 0x71 CHECKSUM 0x17
+    # Footer version 2:
+    # ATENs_FW MAJORVER MINORVER 0x71 CHECKSUM 0x17
 
-	# Footer version 3:
-	# ATENs_FW MAJORVER MINORVER ROOTFS_NFO 0x71 WEBFS_NFO 0x17
+    # Footer version 3:
+    # ATENs_FW MAJORVER MINORVER ROOTFS_NFO 0x71 WEBFS_NFO 0x17
 
-	def __init__(self):
-		# these together get you the firmware version: rev1.rev2
-		self.rev1 = 0
-		self.rev2 = 0
-		self.checksum = 0
-		self.rootfs_nfo = 0
-		self.webfs_nfo = 0
-		# fwtag appears to be some way of recogizing that this is indeed a footer
-		# should be 0x71
-		self.fwtag1 = 0x71
-		# should be 0x17
-		self.fwtag2 = 0x17
-		self.footerver = 3
+    def __init__(self):
+        # these together get you the firmware version: rev1.rev2
+        self.rev1 = 0
+        self.rev2 = 0
+        self.checksum = 0
+        self.rootfs_nfo = 0
+        self.webfs_nfo = 0
+        # fwtag appears to be some way of recogizing that this is indeed a footer
+        # should be 0x71
+        self.fwtag1 = 0x71
+        # should be 0x17
+        self.fwtag2 = 0x17
+        self.footerver = 3
 
-	def loadFromString(self, footer):
-		if len(footer) >= 20:
-			(self.rev1, self.rev2, self.rootfs_nfo, self.fwtag1, self.webfs_nfo, self.fwtag2) = struct.unpack("<bb8sb8sb", footer)
-		# Older footer versions have tags at different offset
-		if len(footer) < 20 or self.fwtag1 != 0x71 or self.fwtag2 != 0x17:
-			self.footerver = 2
-			(self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2) = struct.unpack("<bbbIb", footer)
-			# Seems firmware older then v3.00 uses a different footer, which doesn't have the tag
-			if self.fwtag1 != 0x71 or self.fwtag2 != 0x17:
-				(self.rev1, self.rev2, self.checksum) = struct.unpack("<bbI", footer[:6])
-				self.footerver = 1
-				self.fwtag1 = 0
-				self.fwtag2 = 0
+    def loadFromString(self, footer):
+        if len(footer) >= 20:
+            (self.rev1, self.rev2, self.rootfs_nfo, self.fwtag1, self.webfs_nfo, self.fwtag2) = struct.unpack(b"<BB8sB8sB", footer)
+        # Older footer versions have tags at different offset
+        if len(footer) < 20 or self.fwtag1 != 0x71 or self.fwtag2 != 0x17:
+            self.footerver = 2
+            (self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2) = struct.unpack(b"<BBBIB", footer)
+            # Seems firmware older then v3.00 uses a different footer, which doesn't have the tag
+            if self.fwtag1 != 0x71 or self.fwtag2 != 0x17:
+                (self.rev1, self.rev2, self.checksum) = struct.unpack(b"<BBI", footer[:6])
+                self.footerver = 1
+                self.fwtag1 = 0
+                self.fwtag2 = 0
 
-	def getRawString(self):
-		if self.footerver == 3:
-			contents = "ATENs_FW"+struct.pack("<bb8sb8sb", self.rev1, self.rev2, self.rootfs_nfo, self.fwtag1, self.webfs_nfo, self.fwtag2)
-		elif self.footerver == 2:
-			contents = "ATENs_FW"+struct.pack("<bbbIb", self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2)
-		else:
-			contents = "ATENs_FW"+struct.pack("<bbI", self.rev1, self.rev2, self.checksum)
-		return contents
+    def getRawString(self):
+        if self.footerver == 3:
+            contents = b'ATENs_FW'+struct.pack(b"<BB8sB8sB", self.rev1, self.rev2, self.rootfs_nfo.encode('ISO-8859-1'), self.fwtag1, self.webfs_nfo.encode('ISO-8859-1'), self.fwtag2)
+        elif self.footerver == 2:
+            contents = b'ATENs_FW'+struct.pack(b"<BBBIB", self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2)
+        else:
+            contents = b'ATENs_FW'+struct.pack(b"<BBI", self.rev1, self.rev2, self.checksum)
+        return contents
 
-	def __str__(self):
-		return "Firmware footer version %i firmware version %i.%i checksum: 0x%x tag: 0x%x%x rootfs_nfo: 0x%s webfs_nfo: 0x%s" % (self.footerver, self.rev1, self.rev2, self.checksum, self.fwtag1, self.fwtag2, self.rootfs_nfo, self.webfs_nfo)
+    def __str__(self):
+        return "Firmware footer version %i firmware version %i.%i checksum: 0x%x tag: 0x%x%x rootfs_nfo: 0x%s webfs_nfo: 0x%s" % (self.footerver, self.rev1, self.rev2, self.checksum, self.fwtag1, self.fwtag2, self.rootfs_nfo, self.webfs_nfo)
 
-	def computeFooterChecksum(self, imagecrc):
-		rawCRCBuf = ""
-		for cur in imagecrc:
-			rawCRCBuf += struct.pack("<I",cur)
+    def computeFooterChecksum(self, imagecrc):
+        rawCRCBuf = b''
+        for cur in imagecrc:
+            rawCRCBuf += struct.pack(b"<I",cur)
 
-		return (zlib.crc32(rawCRCBuf) & 0xffffffff)
+        return (zlib.crc32(rawCRCBuf) & 0xffffffff)
 

--- a/ipmifw/FirmwareFooter.py
+++ b/ipmifw/FirmwareFooter.py
@@ -2,6 +2,7 @@
 
 import struct, zlib
 
+
 class FirmwareFooter:
     # Footer version 1:
     # ATENs_FW MAJOR MINOR CHECKSUM
@@ -28,34 +29,72 @@ class FirmwareFooter:
 
     def loadFromString(self, footer):
         if len(footer) >= 20:
-            (self.rev1, self.rev2, self.rootfs_nfo, self.fwtag1, self.webfs_nfo, self.fwtag2) = struct.unpack(b"<BB8sB8sB", footer)
+            (
+                self.rev1,
+                self.rev2,
+                self.rootfs_nfo,
+                self.fwtag1,
+                self.webfs_nfo,
+                self.fwtag2,
+            ) = struct.unpack(b"<BB8sB8sB", footer)
         # Older footer versions have tags at different offset
         if len(footer) < 20 or self.fwtag1 != 0x71 or self.fwtag2 != 0x17:
             self.footerver = 2
-            (self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2) = struct.unpack(b"<BBBIB", footer)
+            (
+                self.rev1,
+                self.rev2,
+                self.fwtag1,
+                self.checksum,
+                self.fwtag2,
+            ) = struct.unpack(b"<BBBIB", footer)
             # Seems firmware older then v3.00 uses a different footer, which doesn't have the tag
             if self.fwtag1 != 0x71 or self.fwtag2 != 0x17:
-                (self.rev1, self.rev2, self.checksum) = struct.unpack(b"<BBI", footer[:6])
+                (self.rev1, self.rev2, self.checksum) = struct.unpack(
+                    b"<BBI", footer[:6]
+                )
                 self.footerver = 1
                 self.fwtag1 = 0
                 self.fwtag2 = 0
 
     def getRawString(self):
         if self.footerver == 3:
-            contents = b'ATENs_FW'+struct.pack(b"<BB8sB8sB", self.rev1, self.rev2, self.rootfs_nfo.encode('ISO-8859-1'), self.fwtag1, self.webfs_nfo.encode('ISO-8859-1'), self.fwtag2)
+            contents = b"ATENs_FW" + struct.pack(
+                b"<BB8sB8sB",
+                self.rev1,
+                self.rev2,
+                self.rootfs_nfo.encode("ISO-8859-1"),
+                self.fwtag1,
+                self.webfs_nfo.encode("ISO-8859-1"),
+                self.fwtag2,
+            )
         elif self.footerver == 2:
-            contents = b'ATENs_FW'+struct.pack(b"<BBBIB", self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2)
+            contents = b"ATENs_FW" + struct.pack(
+                b"<BBBIB", self.rev1, self.rev2, self.fwtag1, self.checksum, self.fwtag2
+            )
         else:
-            contents = b'ATENs_FW'+struct.pack(b"<BBI", self.rev1, self.rev2, self.checksum)
+            contents = b"ATENs_FW" + struct.pack(
+                b"<BBI", self.rev1, self.rev2, self.checksum
+            )
         return contents
 
     def __str__(self):
-        return "Firmware footer version %i firmware version %i.%i checksum: 0x%x tag: 0x%x%x rootfs_nfo: 0x%s webfs_nfo: 0x%s" % (self.footerver, self.rev1, self.rev2, self.checksum, self.fwtag1, self.fwtag2, self.rootfs_nfo, self.webfs_nfo)
+        return (
+            "Firmware footer version %i firmware version %i.%i checksum: 0x%x tag: 0x%x%x rootfs_nfo: 0x%s webfs_nfo: 0x%s"
+            % (
+                self.footerver,
+                self.rev1,
+                self.rev2,
+                self.checksum,
+                self.fwtag1,
+                self.fwtag2,
+                self.rootfs_nfo,
+                self.webfs_nfo,
+            )
+        )
 
     def computeFooterChecksum(self, imagecrc):
-        rawCRCBuf = b''
+        rawCRCBuf = b""
         for cur in imagecrc:
-            rawCRCBuf += struct.pack(b"<I",cur)
+            rawCRCBuf += struct.pack(b"<I", cur)
 
-        return (zlib.crc32(rawCRCBuf) & 0xffffffff)
-
+        return zlib.crc32(rawCRCBuf) & 0xFFFFFFFF

--- a/ipmifw/FirmwareImage.py
+++ b/ipmifw/FirmwareImage.py
@@ -1,91 +1,96 @@
+#!/usr/bin/python
 
 import struct
 
 class FirmwareImage:
-	# indicates the image will be used during boot
-	IMAGE_ACTIVE = 0x01
-	# indicates it should be copied from flash to ram on boot.  Copies *from* the load address to the base address, but only if it's active
-	IMAGE_COPY2RAM = 0x02
-	# indicates control should be passed to the image (how? I dunno)
-	IMAGE_EXEC = 0x04
-	# indicates this is a filesystem image
-	IMAGE_FILE = 0x08
-	# indicates the image is compressed.  Supposedly via ZIP
-	IMAGE_COMPRESSED = 0x10
+    # indicates the image will be used during boot
+    IMAGE_ACTIVE = 0x01
+    # indicates it should be copied from flash to ram on boot.  Copies *from* the load address to the base address, but only if it's active
+    IMAGE_COPY2RAM = 0x02
+    # indicates control should be passed to the image (how? I dunno)
+    IMAGE_EXEC = 0x04
+    # indicates this is a filesystem image
+    IMAGE_FILE = 0x08
+    # indicates the image is compressed.  Supposedly via ZIP
+    IMAGE_COMPRESSED = 0x10
 
-	# This data comes from the "W90P710 Bootloader Users Manual" (find it yourself, I'm not allowed to distribute it)
-	footer_format = "<5I16s4I"
+    # This data comes from the "W90P710 Bootloader Users Manual" (find it yourself, I'm not allowed to distribute it)
+    footer_format = b"<5I16s4I"
 
-	# This signature should be valid if this is a valid firmware image
-	correct_signature = struct.unpack('<I',"\x9f\xff\xff\xa0")[0]
+    # This signature should be valid if this is a valid firmware image
+    correct_signature = struct.unpack(b'<I', b'\x9f\xff\xff\xa0')[0]
 
-        # I largely don't have any idea how or why this works.  It was basically just coding by trival and error.
-        # I'm unsure of why they used this, versus something more standard
-        @staticmethod
-        def computeChecksum(data):
-                cksum = 0xffffffff
+    # I largely don't have any idea how or why this works.  It was basically just coding by trival and error.
+    # I'm unsure of why they used this, versus something more standard
+    @staticmethod
+    def computeChecksum(data):
+        cksum = 0xffffffff
 
-                for i in range(0,len(data)):
-                        char = ord(data[i])
+        for i in range(0,len(data)):
+            # python 2/3 compatibility hack
+            if type(data[i]) is str:
+                char = ord(data[i])
+            else:
+                char = data[i]
 
-                        cksum -= char << ((i%4)*8)
+            cksum -= char << ((i%4)*8)
 
-                        if cksum < 0:
-                                cksum &= 0xffffffff
-                                cksum -= 1
+            if cksum < 0:
+                cksum &= 0xffffffff
+                cksum -= 1
 
-                return cksum
+        return cksum
 
-	def __init__(self):
-		self.imagenum = 0
-		self.base_address = 0
-		self.length = 0
-		self.load_address = 0
-		self.exec_address = 0
-		self.name = 0
-		self.image_checksum = 0
-		self.signature = struct.unpack('<I',"\x9f\xff\xff\xa0")[0]
-		self.type = 0
-		self.footer_checksum = 0
-		
-	def loadFromString(self,footer): 
-		(self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name, self.image_checksum, self.signature, self.type, self.footer_checksum) = struct.unpack(FirmwareImage.footer_format,footer)
-		self.name = self.name.replace("\x00","")
+    def __init__(self):
+        self.imagenum = 0
+        self.base_address = 0
+        self.length = 0
+        self.load_address = 0
+        self.exec_address = 0
+        self.name = 0
+        self.image_checksum = 0
+        self.signature = struct.unpack(b'<I', b'\x9f\xff\xff\xa0')[0]
+        self.type = 0
+        self.footer_checksum = 0
 
-	def getRawString(self):
-		contents = struct.pack("<5I16s4I",self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name, self.image_checksum, self.signature, self.type, self.footer_checksum)
-		return "\xff\xff\xff\xff\xff\xff\xff\xff\xff"+contents+"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+    def loadFromString(self,footer):
+        (self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name, self.image_checksum, self.signature, self.type, self.footer_checksum) = struct.unpack(FirmwareImage.footer_format, footer)
+        self.name = self.name.replace(b"\x00", b"").decode('ISO-8859-1')
 
-	def isValid(self):
-		return self.signature == FirmwareImage.correct_signature
+    def getRawString(self):
+        contents = struct.pack(b"<5I16s4I", self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name.encode('ISO-8859-1'), self.image_checksum, self.signature, self.type, self.footer_checksum)
+        return b"\xff\xff\xff\xff\xff\xff\xff\xff\xff"+contents+b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
 
-	# The footer checksum is only the 48 bytes of actual data (excludes the \xff padding, and the checksum itself)
-	def computeFooterChecksum(self):
-		footer_data = struct.pack("<5I16s3I",self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name, self.image_checksum, self.signature, self.type)
-		return FirmwareImage.computeChecksum(footer_data)
+    def isValid(self):
+        return self.signature == FirmwareImage.correct_signature
+
+    # The footer checksum is only the 48 bytes of actual data (excludes the \xff padding, and the checksum itself)
+    def computeFooterChecksum(self):
+        footer_data = struct.pack(b"<5I16s3I", self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name.encode('ISO-8859-1'), self.image_checksum, self.signature, self.type)
+        return FirmwareImage.computeChecksum(footer_data)
 
 
-	def __str__(self):
-        	flag_desc = []
-        	if self.type & FirmwareImage.IMAGE_ACTIVE:
-                	flag_desc.append('active')
-        	if self.type & FirmwareImage.IMAGE_COPY2RAM:
-                	flag_desc.append('copy2ram')
-        	if self.type & FirmwareImage.IMAGE_EXEC:
-                	flag_desc.append('exec')
-        	if self.type & FirmwareImage.IMAGE_FILE:
-                	flag_desc.append('file')
-	        if self.type & FirmwareImage.IMAGE_COMPRESSED:
-       	        	flag_desc.append('compressed')
+    def __str__(self):
+        flag_desc = []
+        if self.type & FirmwareImage.IMAGE_ACTIVE:
+            flag_desc.append('active')
+        if self.type & FirmwareImage.IMAGE_COPY2RAM:
+            flag_desc.append('copy2ram')
+        if self.type & FirmwareImage.IMAGE_EXEC:
+            flag_desc.append('exec')
+        if self.type & FirmwareImage.IMAGE_FILE:
+            flag_desc.append('file')
+        if self.type & FirmwareImage.IMAGE_COMPRESSED:
+            flag_desc.append('compressed')
 
-		description = "Firmware image: %i Name: %s Base: 0x%x Length: 0x%x (%i) Load: 0x%x Exec: 0x%x Image Checksum: 0x%x Signature: 0x%x Type: %s (0x%x) Footer Checksum: 0x%x" % (self.imagenum, self.name, self.base_address, self.length, self.length, self.load_address, self.exec_address, self.image_checksum, self.signature, ', '.join(flag_desc), self.type, self.footer_checksum)
+        description = "Firmware image: %i Name: %s Base: 0x%x Length: 0x%x (%i) Load: 0x%x Exec: 0x%x Image Checksum: 0x%x Signature: 0x%x Type: %s (0x%x) Footer Checksum: 0x%x" % (self.imagenum, self.name, self.base_address, self.length, self.length, self.load_address, self.exec_address, self.image_checksum, self.signature, ', '.join(flag_desc), self.type, self.footer_checksum)
 
-		computed_footer_checksum = self.computeFooterChecksum()
+        computed_footer_checksum = self.computeFooterChecksum()
 
-		if self.footer_checksum == computed_footer_checksum:
-			description += " * footer checksum matches"
-		else:
-			description += " * footer checksum mismatch, expected 0%x" % computed_footer_checksum
+        if self.footer_checksum == computed_footer_checksum:
+            description += " * footer checksum matches"
+        else:
+            description += " * footer checksum mismatch, expected 0%x" % computed_footer_checksum
 
-		return description		
+        return description
 

--- a/ipmifw/FirmwareImage.py
+++ b/ipmifw/FirmwareImage.py
@@ -2,6 +2,7 @@
 
 import struct
 
+
 class FirmwareImage:
     # indicates the image will be used during boot
     IMAGE_ACTIVE = 0x01
@@ -18,25 +19,25 @@ class FirmwareImage:
     footer_format = b"<5I16s4I"
 
     # This signature should be valid if this is a valid firmware image
-    correct_signature = struct.unpack(b'<I', b'\x9f\xff\xff\xa0')[0]
+    correct_signature = struct.unpack(b"<I", b"\x9f\xff\xff\xa0")[0]
 
     # I largely don't have any idea how or why this works.  It was basically just coding by trival and error.
     # I'm unsure of why they used this, versus something more standard
     @staticmethod
     def computeChecksum(data):
-        cksum = 0xffffffff
+        cksum = 0xFFFFFFFF
 
-        for i in range(0,len(data)):
+        for i in range(0, len(data)):
             # python 2/3 compatibility hack
             if type(data[i]) is str:
                 char = ord(data[i])
             else:
                 char = data[i]
 
-            cksum -= char << ((i%4)*8)
+            cksum -= char << ((i % 4) * 8)
 
             if cksum < 0:
-                cksum &= 0xffffffff
+                cksum &= 0xFFFFFFFF
                 cksum -= 1
 
         return cksum
@@ -49,16 +50,39 @@ class FirmwareImage:
         self.exec_address = 0
         self.name = 0
         self.image_checksum = 0
-        self.signature = struct.unpack(b'<I', b'\x9f\xff\xff\xa0')[0]
+        self.signature = struct.unpack(b"<I", b"\x9f\xff\xff\xa0")[0]
         self.type = 0
         self.footer_checksum = 0
 
-    def loadFromString(self,footer):
-        (self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name, self.image_checksum, self.signature, self.type, self.footer_checksum) = struct.unpack(FirmwareImage.footer_format, footer)
-        self.name = self.name.replace(b"\x00", b"").decode('ISO-8859-1')
+    def loadFromString(self, footer):
+        (
+            self.imagenum,
+            self.base_address,
+            self.length,
+            self.load_address,
+            self.exec_address,
+            self.name,
+            self.image_checksum,
+            self.signature,
+            self.type,
+            self.footer_checksum,
+        ) = struct.unpack(FirmwareImage.footer_format, footer)
+        self.name = self.name.replace(b"\x00", b"").decode("ISO-8859-1")
 
     def getRawString(self):
-        contents = struct.pack(b"<5I16s4I", self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name.encode('ISO-8859-1'), self.image_checksum, self.signature, self.type, self.footer_checksum)
+        contents = struct.pack(
+            b"<5I16s4I",
+            self.imagenum,
+            self.base_address,
+            self.length,
+            self.load_address,
+            self.exec_address,
+            self.name.encode("ISO-8859-1"),
+            self.image_checksum,
+            self.signature,
+            self.type,
+            self.footer_checksum,
+        )
         return b"\xff\xff\xff\xff\xff\xff\xff\xff\xff" + contents
 
     def isValid(self):
@@ -66,31 +90,58 @@ class FirmwareImage:
 
     # The footer checksum is only the 48 bytes of actual data (excludes the \xff padding, and the checksum itself)
     def computeFooterChecksum(self):
-        footer_data = struct.pack(b"<5I16s3I", self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name.encode('ISO-8859-1'), self.image_checksum, self.signature, self.type)
+        footer_data = struct.pack(
+            b"<5I16s3I",
+            self.imagenum,
+            self.base_address,
+            self.length,
+            self.load_address,
+            self.exec_address,
+            self.name.encode("ISO-8859-1"),
+            self.image_checksum,
+            self.signature,
+            self.type,
+        )
         return FirmwareImage.computeChecksum(footer_data)
-
 
     def __str__(self):
         flag_desc = []
         if self.type & FirmwareImage.IMAGE_ACTIVE:
-            flag_desc.append('active')
+            flag_desc.append("active")
         if self.type & FirmwareImage.IMAGE_COPY2RAM:
-            flag_desc.append('copy2ram')
+            flag_desc.append("copy2ram")
         if self.type & FirmwareImage.IMAGE_EXEC:
-            flag_desc.append('exec')
+            flag_desc.append("exec")
         if self.type & FirmwareImage.IMAGE_FILE:
-            flag_desc.append('file')
+            flag_desc.append("file")
         if self.type & FirmwareImage.IMAGE_COMPRESSED:
-            flag_desc.append('compressed')
+            flag_desc.append("compressed")
 
-        description = "Firmware image: %i Name: %s Base: 0x%x Length: 0x%x (%i) Load: 0x%x Exec: 0x%x Image Checksum: 0x%x Signature: 0x%x Type: %s (0x%x) Footer Checksum: 0x%x" % (self.imagenum, self.name, self.base_address, self.length, self.length, self.load_address, self.exec_address, self.image_checksum, self.signature, ', '.join(flag_desc), self.type, self.footer_checksum)
+        description = (
+            "Firmware image: %i Name: %s Base: 0x%x Length: 0x%x (%i) Load: 0x%x Exec: 0x%x Image Checksum: 0x%x Signature: 0x%x Type: %s (0x%x) Footer Checksum: 0x%x"
+            % (
+                self.imagenum,
+                self.name,
+                self.base_address,
+                self.length,
+                self.length,
+                self.load_address,
+                self.exec_address,
+                self.image_checksum,
+                self.signature,
+                ", ".join(flag_desc),
+                self.type,
+                self.footer_checksum,
+            )
+        )
 
         computed_footer_checksum = self.computeFooterChecksum()
 
         if self.footer_checksum == computed_footer_checksum:
             description += " * footer checksum matches"
         else:
-            description += " * footer checksum mismatch, expected 0%x" % computed_footer_checksum
+            description += (
+                " * footer checksum mismatch, expected 0%x" % computed_footer_checksum
+            )
 
         return description
-

--- a/ipmifw/FirmwareImage.py
+++ b/ipmifw/FirmwareImage.py
@@ -59,7 +59,7 @@ class FirmwareImage:
 
     def getRawString(self):
         contents = struct.pack(b"<5I16s4I", self.imagenum, self.base_address, self.length, self.load_address, self.exec_address, self.name.encode('ISO-8859-1'), self.image_checksum, self.signature, self.type, self.footer_checksum)
-        return b"\xff\xff\xff\xff\xff\xff\xff\xff\xff"+contents+b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+        return b"\xff\xff\xff\xff\xff\xff\xff\xff\xff" + contents
 
     def isValid(self):
         return self.signature == FirmwareImage.correct_signature

--- a/ipmifw/Winbond.py
+++ b/ipmifw/Winbond.py
@@ -13,7 +13,7 @@ class Winbond:
 
 		if extract:
 			print "Dumping bootloader to data/bootloader.bin"
-			with open('data/bootloader.bin','w') as f:
+			with open('data/bootloader.bin','wb') as f:
 				f.write(bootloader)
 
 
@@ -45,7 +45,7 @@ class Winbond:
 
 			if extract:
 				print "Dumping 0x%s to 0x%s to data/%s.bin" % (imagestart, imageend, fi.name)
-				with open('data/%s.bin' % fi.name.replace("\x00",""),'w') as f:
+				with open('data/%s.bin' % fi.name.replace("\x00",""),'wb') as f:
 					f.write(ipmifw[imagestart:imageend])
 				computed_image_checksum = FirmwareImage.computeChecksum(ipmifw[imagestart:imageend])
 
@@ -88,7 +88,7 @@ class Winbond:
 
 	def write_bootloader(self, new_image):
 		print "Writing bootloader..."
-		with open('data/bootloader.bin','r') as f:
+		with open('data/bootloader.bin','rb') as f:
 			new_image.write(f.read())
 
 	def process_image(self, config, imagenum, images, cur_image):

--- a/ipmifw/Winbond.py
+++ b/ipmifw/Winbond.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python2.7
+#!/usr/bin/python
 
 import re, hashlib, os, io, argparse, sys, math, zlib
 from ipmifw.FirmwareImage import FirmwareImage
@@ -6,151 +6,149 @@ from ipmifw.FirmwareFooter import FirmwareFooter
 
 
 class Winbond:
-	def parse(self, ipmifw, extract, config):
-		bootloader = ipmifw[:64040]
-		bootloader_md5 = hashlib.md5(bootloader).hexdigest()
+    def parse(self, ipmifw, extract, config):
+        bootloader = ipmifw[:64040]
+        bootloader_md5 = hashlib.md5(bootloader).hexdigest()
+
+        if extract:
+            print("Dumping bootloader to data/bootloader.bin")
+            with open('data/bootloader.bin','wb') as f:
+                f.write(bootloader)
+
+        imagecrc = []
+        # Start by parsing all the different images within the firmware
+        # This method comes directly from the SDK.  Read through the file in 64 byte chunks, and look for the signature at a certain point in the string
+        # Seems kinda scary, as there might be other parts of the file that include this.
+        for i in range(0,len(ipmifw),64):
+            footer = ipmifw[i:i+64]
+
+            fi = FirmwareImage()
+            # 12 bytes of padding.  I think this can really be anything, though it's usually \xFF
+            fi.loadFromString(footer[12:])
+
+            if not fi.isValid():
+                continue
+
+            print("\n"+str(fi))
+
+            imagestart = fi.base_address
+            if imagestart > 0x40000000:
+                # I'm unsure where this 0x40000000 byte offset is coming from.  Perhaps I'm not parsing the footer correctly?
+                imagestart -= 0x40000000
+
+            imageend = imagestart + fi.length
+
+            curcrc = zlib.crc32(ipmifw[imagestart:imageend]) & 0xffffffff
+            imagecrc.append(curcrc)
+
+            if extract:
+                print("Dumping 0x%s to 0x%s to data/%s.bin" % (imagestart, imageend, fi.name))
+                with open('data/%s.bin' % fi.name,'wb') as f:
+                    f.write(ipmifw[imagestart:imageend])
+                computed_image_checksum = FirmwareImage.computeChecksum(ipmifw[imagestart:imageend])
+
+                if computed_image_checksum != fi.image_checksum:
+                    print("Warning: Image checksum mismatch, footer: 0x%x computed: 0x%x" % (fi.image_checksum,computed_image_checksum))
+                else:
+                    print("Image checksum matches")
 
 
-		if extract:
-			print "Dumping bootloader to data/bootloader.bin"
-			with open('data/bootloader.bin','wb') as f:
-				f.write(bootloader)
+            config.set('images', str(fi.imagenum), 'present')
+            configkey = 'image_%i' % fi.imagenum
+            config.add_section(configkey)
+            config.set(configkey, 'length', hex(fi.length))
+            config.set(configkey, 'base_addr', hex(fi.base_address))
+            config.set(configkey, 'load_addr', hex(fi.load_address))
+            config.set(configkey, 'exec_addr', hex(fi.exec_address))
+            config.set(configkey, 'name', fi.name)
+            config.set(configkey, 'type', hex(fi.type))
 
+        # Next, find and validate the global footer
+        for imageFooter in re.findall(b"ATENs_FW(.{8})",ipmifw,re.DOTALL):
+            footer = FirmwareFooter()
+            footer.loadFromString(imageFooter)
+            computed_checksum = footer.computeFooterChecksum(imagecrc)
 
-		imagecrc = []
-		# Start by parsing all the different images within the firmware
-		# This method comes directly from the SDK.  Read through the file in 64 byte chunks, and look for the signature at a certain point in the string
-		# Seems kinda scary, as there might be other parts of the file that include this.
-		for i in range(0,len(ipmifw),64):
-			footer = ipmifw[i:i+64]
+            print("\n"+str(footer))
 
-			fi = FirmwareImage()
-			# 12 bytes of padding.  I think this can really be anything, though it's usually \xFF
-			fi.loadFromString(footer[12:])
+            if footer.checksum == computed_checksum:
+                print("Firmware checksum matches")
+            else:
+                print("Firwamre checksum mismatch, footer: 0x%x computed: 0x%x" % (footer.checksum, computed_checksum))
 
-			if not fi.isValid():
-				continue
+            config.set('global', 'major_version', str(footer.rev1))
+            config.set('global', 'minor_version', str(footer.rev2))
+            config.set('global', 'footer_version', str(footer.footerver))
 
-			print "\n"+str(fi)
+    def init_image(self, new_image, total_size):
+        for i in range(0,total_size):
+            new_image.write(b'\xFF')
 
-			imagestart = fi.base_address
-			if imagestart > 0x40000000:
-				# I'm unsure where this 0x40000000 byte offset is coming from.  Perhaps I'm not parsing the footer correctly?
-				imagestart -= 0x40000000
+    def write_bootloader(self, new_image):
+        print("Writing bootloader...")
+        with open('data/bootloader.bin','rb') as f:
+            new_image.write(f.read())
 
-			imageend = imagestart + fi.length
+    def process_image(self, config, imagenum, images, cur_image):
+        return cur_image
 
-			curcrc = zlib.crc32(ipmifw[imagestart:imageend]) & 0xffffffff
-			imagecrc.append(curcrc)
+    def write_image_footer(self, new_image, cur_image, config, configkey, imagenum, base_addr, name):
+        load_addr = int(config.get(configkey, 'load_addr'),0)
+        exec_addr = int(config.get(configkey, 'exec_addr'),0)
+        type = int(config.get(configkey, 'type'),0)
 
-			if extract:
-				print "Dumping 0x%s to 0x%s to data/%s.bin" % (imagestart, imageend, fi.name)
-				with open('data/%s.bin' % fi.name.replace("\x00",""),'wb') as f:
-					f.write(ipmifw[imagestart:imageend])
-				computed_image_checksum = FirmwareImage.computeChecksum(ipmifw[imagestart:imageend])
+        # Prepare the image footer based on the data
+        # we've stored previously
+        fi = FirmwareImage()
+        fi.imagenum = imagenum
+        fi.base_address = base_addr
+        fi.load_address = load_addr
+        fi.exec_address = exec_addr
+        fi.type = type
+        fi.name = name
+        fi.image_checksum = FirmwareImage.computeChecksum(cur_image)
+        fi.length = len(cur_image)
 
-				if computed_image_checksum != fi.image_checksum:
-					print "Warning: Image checksum mismatch, footer: 0x%x computed: 0x%x" % (fi.image_checksum,computed_image_checksum)
-				else:
-					print "Image checksum matches"
+        # Calculate the new checksum..
+        fi.footer_checksum = fi.computeFooterChecksum()
 
+        # flash chip breaks data down into 64KB blocks.
+        # Footer should be at the end of one of these
+        curblock = int(math.floor(new_image.tell() / 65536))
 
-			config.set('images', str(fi.imagenum), 'present')
-			configkey = 'image_%i' % fi.imagenum
-			config.add_section(configkey)
-			config.set(configkey, 'length', hex(fi.length))
-			config.set(configkey, 'base_addr', hex(fi.base_address))
-			config.set(configkey, 'load_addr', hex(fi.load_address))
-			config.set(configkey, 'exec_addr', hex(fi.exec_address))
-			config.set(configkey, 'name', fi.name)
-			config.set(configkey, 'type', hex(fi.type))
+        curblockend = curblock * 65536
 
-		# Next, find and validate the global footer
-		for imageFooter in re.findall("ATENs_FW(.{8})",ipmifw,re.DOTALL):
-			footer = FirmwareFooter()
-			footer.loadFromString(imageFooter)
-			computed_checksum = footer.computeFooterChecksum(imagecrc)
+        last_image_end = new_image.tell()
 
-			print "\n"+str(footer)
+        # If we don't have space to write the footer
+        # at the end of the current block, move to the next block
+        if curblockend - 61 < last_image_end:
+            curblock += 1
 
-			if footer.checksum == computed_checksum:
-				print "Firmware checksum matches"
-			else:
-				print "Firwamre checksum mismatch, footer: 0x%x computed: 0x%x" % (footer.checksum, computed_checksum)
+        footerpos = (curblock * 65536) - 61
 
-			config.set('global', 'major_version', footer.rev1)
-			config.set('global', 'minor_version', footer.rev2)
-			config.set('global', 'footer_version', footer.footerver)
+        new_image.seek(footerpos)
 
-	def init_image(self, new_image, total_size):
-		for i in range(0,total_size):
-			new_image.write('\xFF')
+        # And write the footer to the output file
+        new_image.write(fi.getRawString())
 
-	def write_bootloader(self, new_image):
-		print "Writing bootloader..."
-		with open('data/bootloader.bin','rb') as f:
-			new_image.write(f.read())
+        return (footerpos, curblockend)
 
-	def process_image(self, config, imagenum, images, cur_image):
-		return cur_image
+    def prepare_global_footer(self, config, footer, footerpos, curblockend):
+        # Hmm... no documentation on where this should be,
+        # but in the firmware I have it's been palced right
+        # before the last image footer
+        # Unsure if that's where it goes, or if it doesn't matter
+        # 16 includes 8 padding \xFF's between the global footer
+        # and the last image footer
+        global_start = footerpos-16
+        if global_start < curblockend:
+            print("ERROR: Would have written global footer over last image")
+            print("Aborting")
+            sys.exit(1)
 
-	def write_image_footer(self, new_image, cur_image, config, configkey, imagenum, base_addr, name):
-                load_addr = int(config.get(configkey, 'load_addr'),0)
-                exec_addr = int(config.get(configkey, 'exec_addr'),0)
-                type = int(config.get(configkey, 'type'),0)
+        return global_start
 
-		# Prepare the image footer based on the data
-		# we've stored previously
-		fi = FirmwareImage()
-		fi.imagenum = imagenum
-		fi.base_address = base_addr
-		fi.load_address = load_addr
-		fi.exec_address = exec_addr
-		fi.type = type
-		fi.name = name
-		fi.image_checksum = FirmwareImage.computeChecksum(cur_image)
-		fi.length = len(cur_image)
+    def write_global_index(self, config, new_image, images):
+        pass
 
-		# Calculate the new checksum..
-		fi.footer_checksum = fi.computeFooterChecksum()
-
-		# flash chip breaks data down into 64KB blocks.
-		# Footer should be at the end of one of these 
-		curblock = int(math.floor(new_image.tell() / 65536))
-
-		curblockend = curblock * 65536
-
-		last_image_end = new_image.tell()
-
-		# If we don't have space to write the footer
-		# at the end of the current block, move to the next block
-		if curblockend - 61 < last_image_end:
-			curblock += 1 
-
-		footerpos = (curblock * 65536) - 61
-
-		new_image.seek(footerpos)
-
-		# And write the footer to the output file
-		new_image.write(fi.getRawString())
-
-		return (footerpos, curblockend)
-
-	def prepare_global_footer(self, config, footer, footerpos, curblockend):
-		# Hmm... no documentation on where this should be,
-		# but in the firmware I have it's been palced right
-		# before the last image footer
-		# Unsure if that's where it goes, or if it doesn't matter
-		# 16 includes 8 padding \xFF's between the global footer
-		# and the last image footer
-		global_start = footerpos-16
-		if global_start < curblockend:
-			print "ERROR: Would have written global footer over last image"
-			print "Aborting"
-			sys.exit(1)
-
-		return global_start
-
-	def write_global_index(self, config, new_image, images):
-		pass
- 

--- a/ipmifw/Winbond.py
+++ b/ipmifw/Winbond.py
@@ -11,7 +11,7 @@ class Winbond:
         bootloader_md5 = hashlib.md5(bootloader).hexdigest()
 
         if extract:
-            print("Dumping bootloader to data/bootloader.bin")
+            print("Dumping bootloader as %#x to %#x to data/bootloader.bin" % (0, 64040))
             with open('data/bootloader.bin','wb') as f:
                 f.write(bootloader)
 
@@ -42,7 +42,7 @@ class Winbond:
             imagecrc.append(curcrc)
 
             if extract:
-                print("Dumping 0x%s to 0x%s to data/%s.bin" % (imagestart, imageend, fi.name))
+                print("Dumping %#x (%s) to %#x (%s) to data/%s.bin" % (imagestart, imagestart, imageend, imageend, fi.name))
                 with open('data/%s.bin' % fi.name,'wb') as f:
                     f.write(ipmifw[imagestart:imageend])
                 computed_image_checksum = FirmwareImage.computeChecksum(ipmifw[imagestart:imageend])
@@ -81,6 +81,7 @@ class Winbond:
             config.set('global', 'footer_version', str(footer.footerver))
 
     def init_image(self, new_image, total_size):
+        print("Initializing image %s with %i bytes" % (new_image.name, total_size))
         for i in range(0,total_size):
             new_image.write(b'\xFF')
 

--- a/read_header.py
+++ b/read_header.py
@@ -26,7 +26,7 @@ type=unknown
 config = ConfigParser()
 config.readfp(io.BytesIO(default_ini))
 
-with open(args.filename,'r') as f:
+with open(args.filename,'rb') as f:
 	ipmifw = f.read()
 
 config.set('flash', 'total_size', len(ipmifw))
@@ -56,7 +56,7 @@ if fwtype == 'unknown':
 
 	if args.extract:
 		print "Dumping bootloader to data/bootloader.bin"
-		with open('data/bootloader.bin','w') as f:
+		with open('data/bootloader.bin','wb') as f:
 			f.write(bootloader)
 
 config.set('global', 'type', fwtype)

--- a/read_header.py
+++ b/read_header.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import re, hashlib, os, io, argparse, sys, zlib
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 from ipmifw.FirmwareImage import FirmwareImage
 from ipmifw.FirmwareFooter import FirmwareFooter
 
@@ -10,7 +10,7 @@ cmdparser.add_argument('--extract',action='store_true',help='Extract any detecte
 cmdparser.add_argument('filename',help='Filename to read from')
 args = cmdparser.parse_args()
 
-default_ini = """
+default_ini = u"""
 [flash]
 total_size=0
 
@@ -24,64 +24,57 @@ type=unknown
 """
 
 config = ConfigParser()
-config.readfp(io.BytesIO(default_ini))
+config.read_string(default_ini)
 
 with open(args.filename,'rb') as f:
-	ipmifw = f.read()
+    ipmifw = f.read()
 
-config.set('flash', 'total_size', len(ipmifw))
+config.set("flash", "total_size", str(len(ipmifw)))
 
 try:
-	os.mkdir('data')
+    os.mkdir('data')
 except OSError:
-	pass
+    pass
 
-print "Read %i bytes" % len(ipmifw)
+print("Read %i bytes" % len(ipmifw))
 
 fwtype = 'unknown'
 if len(ipmifw) > 0x01fc0000:
-	if ipmifw[0x01fc0000:0x01fc0005] == '[img]':
-		fwtype = 'aspeed'
+    if ipmifw[0x01fc0000:0x01fc0005] == b'[img]':
+        fwtype = 'aspeed'
 
 if fwtype == 'unknown':
-	bootloader = ipmifw[:64040]
-	bootloader_md5 = hashlib.md5(bootloader).hexdigest()
-
-	if bootloader_md5 != "166162c6c9f21d7a710dfd62a3452684":
-		print "Warning: bootloader (first 64040 bytes of file) md5 doesn't match.  This parser may not work with a different bootloader"
-		print "Expected 166162c6c9f21d7a710dfd62a3452684, got %s" % bootloader_md5
-	else:
-		print "Bootloader md5 matches, this parser will probably work!"
-		fwtype = 'winbond'
-
-	if args.extract:
-		print "Dumping bootloader to data/bootloader.bin"
-		with open('data/bootloader.bin','wb') as f:
-			f.write(bootloader)
+    bootloader = ipmifw[:64040]
+    bootloader_md5 = hashlib.md5(bootloader).hexdigest()
+    if bootloader_md5 != "166162c6c9f21d7a710dfd62a3452684":
+        print("Warning: bootloader (first 64040 bytes of file) md5 doesn't match.  This parser may not work with a different bootloader")
+        print("Expected 166162c6c9f21d7a710dfd62a3452684, got %s" % bootloader_md5)
+    else:
+        fwtype = 'winbond'
 
 config.set('global', 'type', fwtype)
 
 if fwtype == 'winbond':
-	from ipmifw.Winbond import Winbond
+    from ipmifw.Winbond import Winbond
 
-	firmware = Winbond()
-	firmware.parse(ipmifw, args.extract, config)
+    firmware = Winbond()
+    firmware.parse(ipmifw, args.extract, config)
 
 elif fwtype == 'aspeed':
-	from ipmifw.ASpeed import ASpeed
+    from ipmifw.ASpeed import ASpeed
 
-	config.set('global', 'footer_version', 3)
-	firmware = ASpeed()
-	firmware.parse(ipmifw, args.extract, config)
+    config.set('global', 'footer_version', '3')
+    firmware = ASpeed()
+    firmware.parse(ipmifw, args.extract, config)
 
 else:
-	print "Error: Unable to determine what type of IPMI firmware this is!"
-	sys.exit(1)
+    print("Error: Unable to determine what type of IPMI firmware this is!")
+    sys.exit(1)
 
 
 if args.extract:
-	with open('data/image.ini','w') as f:
-		config.write(f)
+    with open('data/image.ini','w') as f:
+        config.write(f)
 else:
-	print "\nConfiguration info:\n"
-	config.write(sys.stdout)
+    print("\nConfiguration info:\n")
+    config.write(sys.stdout)

--- a/read_header.py
+++ b/read_header.py
@@ -23,6 +23,11 @@ type=unknown
 [images]
 """
 
+bootloader_md5sums = {
+    "649f3b6a0c9d67ff90c6d9daaa4dd9b9": "WPCM450 Boot Loader [ Version:1.0.14 ] Rebuilt on Oct 15 2010",
+    "166162c6c9f21d7a710dfd62a3452684": "WPCM450 Boot Loader [ Version:1.0.14 ] Rebuilt on Mar 23 2012",
+}
+
 config = ConfigParser()
 config.read_string(default_ini)
 
@@ -46,12 +51,14 @@ if len(ipmifw) > 0x01fc0000:
 if fwtype == 'unknown':
     bootloader = ipmifw[:64040]
     bootloader_md5 = hashlib.md5(bootloader).hexdigest()
-    if bootloader_md5 != "166162c6c9f21d7a710dfd62a3452684":
+    if bootloader_md5 not in bootloader_md5sums.keys():
         print("Warning: bootloader (first 64040 bytes of file) md5 doesn't match.  This parser may not work with a different bootloader")
-        print("Expected 166162c6c9f21d7a710dfd62a3452684, got %s" % bootloader_md5)
+        print("Expected %s, got %s" % (" or ".join([x for x in bootloader_md5sums.keys()]), bootloader_md5))
     else:
+        print("Detected valid bootloader: %s" % bootloader_md5sums[bootloader_md5])
         fwtype = 'winbond'
 
+print()
 config.set('global', 'type', fwtype)
 
 if fwtype == 'winbond':

--- a/read_header.py
+++ b/read_header.py
@@ -5,12 +5,16 @@ from configparser import ConfigParser
 from ipmifw.FirmwareImage import FirmwareImage
 from ipmifw.FirmwareFooter import FirmwareFooter
 
-cmdparser = argparse.ArgumentParser(description='Read and extract data from SuperMicro IPMI firmware')
-cmdparser.add_argument('--extract',action='store_true',help='Extract any detected firmware images')
-cmdparser.add_argument('filename',help='Filename to read from')
+cmdparser = argparse.ArgumentParser(
+    description="Read and extract data from SuperMicro IPMI firmware"
+)
+cmdparser.add_argument(
+    "--extract", action="store_true", help="Extract any detected firmware images"
+)
+cmdparser.add_argument("filename", help="Filename to read from")
 args = cmdparser.parse_args()
 
-default_ini = u"""
+default_ini = """
 [flash]
 total_size=0
 
@@ -31,46 +35,51 @@ bootloader_md5sums = {
 config = ConfigParser()
 config.read_string(default_ini)
 
-with open(args.filename,'rb') as f:
+with open(args.filename, "rb") as f:
     ipmifw = f.read()
 
 config.set("flash", "total_size", str(len(ipmifw)))
 
 try:
-    os.mkdir('data')
+    os.mkdir("data")
 except OSError:
     pass
 
 print("Read %i bytes" % len(ipmifw))
 
-fwtype = 'unknown'
-if len(ipmifw) > 0x01fc0000:
-    if ipmifw[0x01fc0000:0x01fc0005] == b'[img]':
-        fwtype = 'aspeed'
+fwtype = "unknown"
+if len(ipmifw) > 0x01FC0000:
+    if ipmifw[0x01FC0000:0x01FC0005] == b"[img]":
+        fwtype = "aspeed"
 
-if fwtype == 'unknown':
+if fwtype == "unknown":
     bootloader = ipmifw[:64040]
     bootloader_md5 = hashlib.md5(bootloader).hexdigest()
     if bootloader_md5 not in bootloader_md5sums.keys():
-        print("Warning: bootloader (first 64040 bytes of file) md5 doesn't match.  This parser may not work with a different bootloader")
-        print("Expected %s, got %s" % (" or ".join([x for x in bootloader_md5sums.keys()]), bootloader_md5))
+        print(
+            "Warning: bootloader (first 64040 bytes of file) md5 doesn't match.  This parser may not work with a different bootloader"
+        )
+        print(
+            "Expected %s, got %s"
+            % (" or ".join([x for x in bootloader_md5sums.keys()]), bootloader_md5)
+        )
     else:
         print("Detected valid bootloader: %s" % bootloader_md5sums[bootloader_md5])
-        fwtype = 'winbond'
+        fwtype = "winbond"
 
 print()
-config.set('global', 'type', fwtype)
+config.set("global", "type", fwtype)
 
-if fwtype == 'winbond':
+if fwtype == "winbond":
     from ipmifw.Winbond import Winbond
 
     firmware = Winbond()
     firmware.parse(ipmifw, args.extract, config)
 
-elif fwtype == 'aspeed':
+elif fwtype == "aspeed":
     from ipmifw.ASpeed import ASpeed
 
-    config.set('global', 'footer_version', '3')
+    config.set("global", "footer_version", "3")
     firmware = ASpeed()
     firmware.parse(ipmifw, args.extract, config)
 
@@ -80,7 +89,7 @@ else:
 
 
 if args.extract:
-    with open('data/image.ini','w') as f:
+    with open("data/image.ini", "w") as f:
         config.write(f)
 else:
     print("\nConfiguration info:\n")

--- a/rebuild_image.py
+++ b/rebuild_image.py
@@ -19,7 +19,7 @@ else:
 	from ipmifw.Winbond import Winbond
 	firmware = Winbond()
 
-new_image = open('data/rebuilt_image.bin','w')
+new_image = open('data/rebuilt_image.bin','wb')
 new_image.truncate()
 
 # initialize new image
@@ -65,7 +65,7 @@ for imagenum in images:
 		fname = name + '.bin'
 	else:
 		fname = name
-	with open('data/%s' % fname,'r') as img:
+	with open('data/%s' % fname,'rb') as img:
 		cur_image = firmware.process_image(config, imagenum, images, img.read())
 
 	# Write the actual image contents

--- a/rebuild_image.py
+++ b/rebuild_image.py
@@ -1,23 +1,23 @@
 #!/usr/bin/python
 
 import os, io, sys, zlib
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 from ipmifw.FirmwareImage import FirmwareImage
 from ipmifw.FirmwareFooter import FirmwareFooter
 
 config = ConfigParser()
 try:
-	config.read('data/image.ini')
+    config.read('data/image.ini')
 except:
-	print "Unable to read image configuration"
-	os.exit(1)
+    print("Unable to read image configuration")
+    os.exit(1)
 
 if config.get('global','type') == 'aspeed':
-	from ipmifw.ASpeed import ASpeed
-	firmware = ASpeed()
+    from ipmifw.ASpeed import ASpeed
+    firmware = ASpeed()
 else:
-	from ipmifw.Winbond import Winbond
-	firmware = Winbond()
+    from ipmifw.Winbond import Winbond
+    firmware = Winbond()
 
 new_image = open('data/rebuilt_image.bin','wb')
 new_image.truncate()
@@ -33,52 +33,52 @@ firmware.write_bootloader(new_image)
 # prepare list of images to write
 images = []
 for (imagenum, dummy) in config.items('images'):
-	images.append(int(imagenum))
+    images.append(int(imagenum))
 
 images.sort()
 
 imagecrc = []
 # write all images into the firmware file
 for imagenum in images:
-	print "Processing image %i"  % imagenum
+    configkey = 'image_%i' % imagenum
 
-	configkey = 'image_%i' % imagenum
+    # can't use getint, it doesn't support hex
+    base_addr = int(config.get(configkey, 'base_addr'),0)
+    name = config.get(configkey, 'name')
 
-	# can't use getint, it doesn't support hex
-	base_addr = int(config.get(configkey, 'base_addr'),0)
-	name = config.get(configkey, 'name')
+    imagestart = base_addr
+    if imagestart > 0x40000000:
+        # I'm unsure where this 0x40000000 byte offset is coming from.  Perhaps I'm not parsing the footer correctly?
+        imagestart -= 0x40000000
 
-	imagestart = base_addr
-	if imagestart > 0x40000000:
-		# I'm unsure where this 0x40000000 byte offset is coming from.  Perhaps I'm not parsing the footer correctly?
-		imagestart -= 0x40000000
+    print("Processing image %i: %s at 0x%X"  % (imagenum, name, base_addr))
 
-	if imagestart < new_image.tell():
-		print "ERROR: Previous image was too big, and has overriten data where the current image should begin."
-		print "Aborting."
-		sys.exit(1)
+    if imagestart < new_image.tell():
+        print("ERROR: Previous image was too big, and has overriten data where the current image should begin.")
+        print("Aborting.")
+        sys.exit(1)
 
-	# Seek to where this image will start	
-	new_image.seek(imagestart)
+    # Seek to where this image will start
+    new_image.seek(imagestart)
 
-	if name[-4:] != '.bin':
-		fname = name + '.bin'
-	else:
-		fname = name
-	with open('data/%s' % fname,'rb') as img:
-		cur_image = firmware.process_image(config, imagenum, images, img.read())
+    if name[-4:] != '.bin':
+        fname = name + '.bin'
+    else:
+        fname = name
+    with open('data/%s' % fname,'rb') as img:
+        cur_image = firmware.process_image(config, imagenum, images, img.read())
 
-	# Write the actual image contents
-	new_image.write(cur_image)	
+    # Write the actual image contents
+    new_image.write(cur_image)
 
-	# Compute the CRC32 of this image.  This is used for the global footer, not for each individual footer
-	curcrc = zlib.crc32(cur_image) & 0xffffffff
-	imagecrc.append(curcrc)
+    # Compute the CRC32 of this image.  This is used for the global footer, not for each individual footer
+    curcrc = zlib.crc32(cur_image) & 0xffffffff
+    imagecrc.append(curcrc)
 
-	config.set(configkey, 'curcrc', '0x%x' % curcrc)
-	config.set(configkey, 'curlen', '0x%x' % len(cur_image))
+    config.set(configkey, 'curcrc', '0x%x' % curcrc)
+    config.set(configkey, 'curlen', '0x%x' % len(cur_image))
 
-	(footerpos, curblockend) = firmware.write_image_footer(new_image, cur_image, config, configkey, imagenum, base_addr, name)
+    (footerpos, curblockend) = firmware.write_image_footer(new_image, cur_image, config, configkey, imagenum, base_addr, name)
 
 footer = FirmwareFooter()
 footer.rev1 = int(config.get('global','major_version'),0)
@@ -92,6 +92,6 @@ new_image.seek(global_start)
 new_image.write(footer.getRawString())
 
 firmware.write_global_index(config, new_image, images)
- 
-print "Done, new firmware written to data/rebuild_image.bin"
+
+print("Done, new firmware written to data/rebuild_image.bin")
 

--- a/rebuild_image.py
+++ b/rebuild_image.py
@@ -7,23 +7,25 @@ from ipmifw.FirmwareFooter import FirmwareFooter
 
 config = ConfigParser()
 try:
-    config.read('data/image.ini')
+    config.read("data/image.ini")
 except:
     print("Unable to read image configuration")
     os.exit(1)
 
-if config.get('global','type') == 'aspeed':
+if config.get("global", "type") == "aspeed":
     from ipmifw.ASpeed import ASpeed
+
     firmware = ASpeed()
 else:
     from ipmifw.Winbond import Winbond
+
     firmware = Winbond()
 
-new_image = open('data/rebuilt_image.bin','wb')
+new_image = open("data/rebuilt_image.bin", "wb")
 new_image.truncate()
 
 # initialize new image
-total_size = config.getint('flash','total_size')
+total_size = config.getint("flash", "total_size")
 firmware.init_image(new_image, total_size)
 new_image.seek(0)
 
@@ -32,7 +34,7 @@ firmware.write_bootloader(new_image)
 
 # prepare list of images to write
 images = []
-for (imagenum, dummy) in config.items('images'):
+for (imagenum, dummy) in config.items("images"):
     images.append(int(imagenum))
 
 images.sort()
@@ -40,50 +42,54 @@ images.sort()
 imagecrc = []
 # write all images into the firmware file
 for imagenum in images:
-    configkey = 'image_%i' % imagenum
+    configkey = "image_%i" % imagenum
 
     # can't use getint, it doesn't support hex
-    base_addr = int(config.get(configkey, 'base_addr'),0)
-    name = config.get(configkey, 'name')
+    base_addr = int(config.get(configkey, "base_addr"), 0)
+    name = config.get(configkey, "name")
 
     imagestart = base_addr
     if imagestart > 0x40000000:
         # I'm unsure where this 0x40000000 byte offset is coming from.  Perhaps I'm not parsing the footer correctly?
         imagestart -= 0x40000000
 
-    print("Processing image %i: %s at 0x%X"  % (imagenum, name, base_addr))
+    print("Processing image %i: %s at 0x%X" % (imagenum, name, base_addr))
 
     if imagestart < new_image.tell():
-        print("ERROR: Previous image was too big, and has overriten data where the current image should begin.")
+        print(
+            "ERROR: Previous image was too big, and has overriten data where the current image should begin."
+        )
         print("Aborting.")
         sys.exit(1)
 
     # Seek to where this image will start
     new_image.seek(imagestart)
 
-    if name[-4:] != '.bin':
-        fname = name + '.bin'
+    if name[-4:] != ".bin":
+        fname = name + ".bin"
     else:
         fname = name
-    with open('data/%s' % fname,'rb') as img:
+    with open("data/%s" % fname, "rb") as img:
         cur_image = firmware.process_image(config, imagenum, images, img.read())
 
     # Write the actual image contents
     new_image.write(cur_image)
 
     # Compute the CRC32 of this image.  This is used for the global footer, not for each individual footer
-    curcrc = zlib.crc32(cur_image) & 0xffffffff
+    curcrc = zlib.crc32(cur_image) & 0xFFFFFFFF
     imagecrc.append(curcrc)
 
-    config.set(configkey, 'curcrc', '0x%x' % curcrc)
-    config.set(configkey, 'curlen', '0x%x' % len(cur_image))
+    config.set(configkey, "curcrc", "0x%x" % curcrc)
+    config.set(configkey, "curlen", "0x%x" % len(cur_image))
 
-    (footerpos, curblockend) = firmware.write_image_footer(new_image, cur_image, config, configkey, imagenum, base_addr, name)
+    (footerpos, curblockend) = firmware.write_image_footer(
+        new_image, cur_image, config, configkey, imagenum, base_addr, name
+    )
 
 footer = FirmwareFooter()
-footer.rev1 = int(config.get('global','major_version'),0)
-footer.rev2 = int(config.get('global','minor_version'),0)
-footer.footerver = int(config.get('global','footer_version'),0)
+footer.rev1 = int(config.get("global", "major_version"), 0)
+footer.rev2 = int(config.get("global", "minor_version"), 0)
+footer.footerver = int(config.get("global", "footer_version"), 0)
 footer.checksum = footer.computeFooterChecksum(imagecrc)
 
 # Write the global footer
@@ -94,4 +100,3 @@ new_image.write(footer.getRawString())
 firmware.write_global_index(config, new_image, images)
 
 print("Done, new firmware written to data/rebuild_image.bin")
-

--- a/test-all
+++ b/test-all
@@ -11,6 +11,9 @@
 
 ORIG_FW=FW/*.bin
 
+py_ver=`python --version 2>&1`
+echo "Using $py_ver"
+
 for f in $ORIG_FW
 do
 	echo "Processing $f..."


### PR DESCRIPTION
This PR is for a few combined changes and improvements:

 * Pull in PR #4 which is basically required nowadays, old code is for Python2 and that is not around much anymore.
 * Instead of one hardcoded md5sum for a bootloader, allow multiple keyed off the md5sum.
 * Add a different WPCM450 Boot Loader in the 2010 version as seen on the `SMT_316.bin` file.
 * Improve program output: More detail what the program does and which data is being copied.
 * Fix #5 by only returning 64bytes instead of 80 for getRawString().
 * Apply `black` code formatting (https://github.com/psf/black) to make the code comply to pycodestyle.