### PR TITLE
Add support for null-bytes in image name

### DIFF
--- a/ipmifw/ASpeed.py
+++ b/ipmifw/ASpeed.py
@@ -9,7 +9,7 @@ class ASpeed:
         footer = ipmifw[0x01FC0000:].decode("ISO-8859-1")
         imagenum = 1
         # There's a nice handy block at the end of the file that gives information about all the embedded images!
-        for (imagestart, length, checksum, filename) in re.findall(
+        for imagestart, length, checksum, filename in re.findall(
             "\[img\]: ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z]+) ([0-9a-z\-_.]+)", footer
         ):
             imagestart = int(imagestart, 16)
@@ -93,13 +93,13 @@ class ASpeed:
             os.exit(1)
         # space for uboot bootloader
         for i in range(0, 0x100000):
-            new_image.write(b"\xFF")
+            new_image.write(b"\xff")
         # nvram block, not referenced in the footer
         for i in range(0x100000, 0x400000):
             new_image.write(b"\x00")
         # root_fs, kernel and web_fs
         for i in range(0x400000, 0x1F40000):
-            new_image.write(b"\xFF")
+            new_image.write(b"\xff")
         # bootloader env aka footer
         for i in range(0x1F40000, total_size):
             new_image.write(b"\x00")

--- a/ipmifw/FirmwareImage.py
+++ b/ipmifw/FirmwareImage.py
@@ -67,6 +67,8 @@ class FirmwareImage:
             self.type,
             self.footer_checksum,
         ) = struct.unpack(FirmwareImage.footer_format, footer)
+        # Preserve the raw name for correct reassembly
+        self.name_raw = self.name
         self.name = self.name.replace(b"\x00", b"").decode("ISO-8859-1")
 
     def getRawString(self):

--- a/ipmifw/Winbond.py
+++ b/ipmifw/Winbond.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import re, hashlib, os, io, argparse, sys, math, zlib
+import base64, re, hashlib, os, io, argparse, sys, math, zlib
 from ipmifw.FirmwareImage import FirmwareImage
 from ipmifw.FirmwareFooter import FirmwareFooter
 
@@ -70,6 +70,11 @@ class Winbond:
             config.set(configkey, "load_addr", hex(fi.load_address))
             config.set(configkey, "exec_addr", hex(fi.exec_address))
             config.set(configkey, "name", fi.name)
+            config.set(
+                configkey,
+                "name_raw",
+                base64.b64encode(fi.name_raw).decode("ISO-8859-1"),
+            )
             config.set(configkey, "type", hex(fi.type))
 
         # Next, find and validate the global footer
@@ -95,7 +100,7 @@ class Winbond:
     def init_image(self, new_image, total_size):
         print("Initializing image %s with %i bytes" % (new_image.name, total_size))
         for i in range(0, total_size):
-            new_image.write(b"\xFF")
+            new_image.write(b"\xff")
 
     def write_bootloader(self, new_image):
         print("Writing bootloader...")

--- a/test-all
+++ b/test-all
@@ -16,6 +16,7 @@ echo "Using $py_ver"
 
 for f in $ORIG_FW
 do
+	echo "###############################"
 	echo "Processing $f..."
 	rm data/*
 	python ./read_header.py --extract $f
@@ -25,5 +26,6 @@ do
 		echo "ERROR, output file differs from the input image"
 		exit 1
 	fi
+	echo
 done
 


### PR DESCRIPTION
Have a base64 encoded representation of the original name in `FirmwareImage.name_raw`.

`name` is used for the on-disk representation of the file name.
`name_raw` is used for the in-image naming of the subpart.

Drive-By:
- Reformat Aspeed using `black`.
- Use `.endswith()` instead if `[-4:]` to check if the file has a `.bin` extension.
- Slightly better output in the `test-all` script to have a separator between imageds.

Fixes: https://github.com/devicenull/ipmi_firmware_tools/issues/11